### PR TITLE
Improve types to have more compatibility with `@types/http-proxy`

### DIFF
--- a/lib/http-proxy/index.ts
+++ b/lib/http-proxy/index.ts
@@ -32,55 +32,55 @@ export interface ServerOptions {
   // actually proxying is called.  However, they can be missing when creating the
   // proxy server in the first place!  E.g., you could make a proxy server P with
   // no options, then use P.web(req,res, {target:...}).
-  // URL string to be parsed with the url module.
+  /** URL string to be parsed with the url module. */
   target?: ProxyTarget;
-  // URL string to be parsed with the url module or a URL object.
+  /** URL string to be parsed with the url module or a URL object. */
   forward?: ProxyTargetUrl;
-  // Object to be passed to http(s).request.
+  /** Object to be passed to http(s).request. */
   agent?: any;
-  // Object to be passed to https.createServer().
+  /** Object to be passed to https.createServer(). */
   ssl?: any;
-  // If you want to proxy websockets.
+  /** If you want to proxy websockets. */
   ws?: boolean;
-  // Adds x- forward headers.
+  /** Adds x- forward headers. */
   xfwd?: boolean;
-  // Verify SSL certificate.
+  /** Verify SSL certificate. */
   secure?: boolean;
-  // Explicitly specify if we are proxying to another proxy.
+  /** Explicitly specify if we are proxying to another proxy. */
   toProxy?: boolean;
-  // Specify whether you want to prepend the target's path to the proxy path.
+  /** Specify whether you want to prepend the target's path to the proxy path. */
   prependPath?: boolean;
-  // Specify whether you want to ignore the proxy path of the incoming request.
+  /** Specify whether you want to ignore the proxy path of the incoming request. */
   ignorePath?: boolean;
-  // Local interface string to bind for outgoing connections.
+  /** Local interface string to bind for outgoing connections. */
   localAddress?: string;
-  // Changes the origin of the host header to the target URL.
+  /** Changes the origin of the host header to the target URL. */
   changeOrigin?: boolean;
-  // specify whether you want to keep letter case of response header key
+  /** specify whether you want to keep letter case of response header key */
   preserveHeaderKeyCase?: boolean;
-  // Basic authentication i.e. 'user:password' to compute an Authorization header.
+  /** Basic authentication i.e. 'user:password' to compute an Authorization header. */
   auth?: string;
-  // Rewrites the location hostname on (301 / 302 / 307 / 308) redirects, Default: null.
+  /** Rewrites the location hostname on (301 / 302 / 307 / 308) redirects, Default: null. */
   hostRewrite?: string;
-  // Rewrites the location host/ port on (301 / 302 / 307 / 308) redirects based on requested host/ port.Default: false.
+  /** Rewrites the location host/ port on (301 / 302 / 307 / 308) redirects based on requested host/ port.Default: false. */
   autoRewrite?: boolean;
-  // Rewrites the location protocol on (301 / 302 / 307 / 308) redirects to 'http' or 'https'.Default: null.
+  /** Rewrites the location protocol on (301 / 302 / 307 / 308) redirects to 'http' or 'https'.Default: null. */
   protocolRewrite?: string;
-  // rewrites domain of set-cookie headers.
+  /** rewrites domain of set-cookie headers. */
   cookieDomainRewrite?: false | string | { [oldDomain: string]: string };
-  // rewrites path of set-cookie headers. Default: false
+  /** rewrites path of set-cookie headers. Default: false */
   cookiePathRewrite?: false | string | { [oldPath: string]: string };
-  // object with extra headers to be added to target requests.
+  /** object with extra headers to be added to target requests. */
   headers?: { [header: string]: string | string[] | undefined };
-  // Timeout (in milliseconds) when proxy receives no response from target. Default: 120000 (2 minutes)
+  /** Timeout (in milliseconds) when proxy receives no response from target. Default: 120000 (2 minutes) */
   proxyTimeout?: number;
-  // Timeout (in milliseconds) for incoming requests
+  /** Timeout (in milliseconds) for incoming requests */
   timeout?: number;
-  // Specify whether you want to follow redirects. Default: false
+  /** Specify whether you want to follow redirects. Default: false */
   followRedirects?: boolean;
-  // If set to true, none of the webOutgoing passes are called and it's your responsibility to appropriately return the response by listening and acting on the proxyRes event
+  /** If set to true, none of the webOutgoing passes are called and it's your responsibility to appropriately return the response by listening and acting on the proxyRes event */
   selfHandleResponse?: boolean;
-  // Buffer
+  /** Buffer */
   buffer?: Stream;
 }
 

--- a/lib/http-proxy/index.ts
+++ b/lib/http-proxy/index.ts
@@ -85,7 +85,20 @@ export interface ServerOptions {
 }
 
 export class ProxyServer extends EventEmitter {
+  /**
+   * Used for proxying WS(S) requests
+   * @param req - Client request.
+   * @param socket - Client socket.
+   * @param head - Client head.
+   * @param options - Additional options.
+   */
   public readonly ws;
+  /**
+   * Used for proxying regular HTTP(S) requests
+   * @param req - Client request.
+   * @param res - Client response.
+   * @param options - Additional options.
+   */
   public readonly web;
 
   private options: ServerOptions;
@@ -93,6 +106,10 @@ export class ProxyServer extends EventEmitter {
   private wsPasses;
   private _server?;
 
+  /**
+   * Creates the proxy server with specified options.
+   * @param options - Config object passed to the proxy
+   */
   constructor(options: ServerOptions = {}) {
     super();
     log("creating a ProxyServer", options);
@@ -187,6 +204,11 @@ export class ProxyServer extends EventEmitter {
     }
   };
 
+  /**
+   * A function that wraps the object in a webserver, for your convenience
+   * @param port - Port to listen on
+   * @param hostname - The hostname to listen on
+   */
   listen = (port: number, hostname?: string) => {
     log("listen", { port, hostname });
 
@@ -210,6 +232,9 @@ export class ProxyServer extends EventEmitter {
     return this._server?.address();
   };
 
+  /**
+   * A function that closes the inner webserver and stops listening on given port
+   */
   close = (cb?: Function) => {
     if (this._server == null) {
       cb?.();

--- a/lib/http-proxy/index.ts
+++ b/lib/http-proxy/index.ts
@@ -1,5 +1,6 @@
 import * as http from "http";
 import * as https from "https";
+import * as net from "net";
 import { WEB_PASSES } from "./passes/web-incoming";
 import { WS_PASSES } from "./passes/ws-incoming";
 import { EventEmitter } from "events";
@@ -84,6 +85,14 @@ export interface ServerOptions {
   buffer?: Stream;
 }
 
+export type ErrorCallback =
+  (
+    err: Error,
+    req: http.IncomingMessage,
+    res: http.ServerResponse | net.Socket,
+    target?: ProxyTargetUrl,
+  ) => void;
+
 export class ProxyServer extends EventEmitter {
   /**
    * Used for proxying WS(S) requests
@@ -92,14 +101,43 @@ export class ProxyServer extends EventEmitter {
    * @param head - Client head.
    * @param options - Additional options.
    */
-  public readonly ws;
+  public readonly ws: (
+    ...args:
+      [
+        req: http.IncomingMessage,
+        socket: any,
+        head: any,
+        options?: ServerOptions,
+        callback?: ErrorCallback,
+      ]
+    | [
+        req: http.IncomingMessage,
+        socket: any,
+        head: any,
+        callback?: ErrorCallback,
+      ]
+  ) => void;
+
   /**
    * Used for proxying regular HTTP(S) requests
    * @param req - Client request.
    * @param res - Client response.
    * @param options - Additional options.
    */
-  public readonly web;
+  public readonly web: (
+    ...args:
+      [
+        req: http.IncomingMessage,
+        res: http.ServerResponse,
+        options: ServerOptions,
+        callback?: ErrorCallback,
+      ]
+    | [
+        req: http.IncomingMessage,
+        res: http.ServerResponse,
+        callback?: ErrorCallback
+      ]
+  ) => void;
 
   private options: ServerOptions;
   private webPasses;

--- a/lib/http-proxy/index.ts
+++ b/lib/http-proxy/index.ts
@@ -122,6 +122,33 @@ export class ProxyServer extends EventEmitter {
     this.on("error", this.onError);
   }
 
+  /**
+   * Creates the proxy server with specified options.
+   * @param options Config object passed to the proxy
+   * @returns Proxy object with handlers for `ws` and `web` requests
+   */
+  static createProxyServer(options?: ServerOptions): ProxyServer {
+    return new ProxyServer(options);
+  }
+
+  /**
+   * Creates the proxy server with specified options.
+   * @param options Config object passed to the proxy
+   * @returns Proxy object with handlers for `ws` and `web` requests
+   */
+  static createServer(options?: ServerOptions): ProxyServer {
+    return new ProxyServer(options);
+  }
+
+  /**
+   * Creates the proxy server with specified options.
+   * @param options Config object passed to the proxy
+   * @returns Proxy object with handlers for `ws` and `web` requests
+   */
+  static createProxy(options?: ServerOptions): ProxyServer {
+    return new ProxyServer(options);
+  }
+
   // createRightProxy - Returns a function that when called creates the loader for
   // either `ws` or `web`'s passes.
   createRightProxy = (type: ProxyType): Function => {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,6 +1,18 @@
-import { ProxyServer, type ServerOptions, type ProxyTarget, type ProxyTargetUrl } from "./http-proxy/index";
-export { ProxyServer, type ServerOptions, type ProxyTarget, type ProxyTargetUrl };
-export { numOpenSockets } from "./http-proxy/passes/ws-incoming";
+import {
+  ProxyServer,
+  type ServerOptions,
+  type ProxyTarget,
+  type ProxyTargetUrl,
+  type ErrorCallback,
+} from './http-proxy/index';
+export {
+  ProxyServer,
+  type ServerOptions,
+  type ProxyTarget,
+  type ProxyTargetUrl,
+  type ErrorCallback,
+};
+export { numOpenSockets } from './http-proxy/passes/ws-incoming';
 
 /**
  * Creates the proxy server.

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,5 +1,5 @@
-import { ProxyServer, type ServerOptions } from "./http-proxy/index";
-export { ProxyServer };
+import { ProxyServer, type ServerOptions, type ProxyTarget, type ProxyTargetUrl } from "./http-proxy/index";
+export { ProxyServer, type ServerOptions, type ProxyTarget, type ProxyTargetUrl };
 export { numOpenSockets } from "./http-proxy/passes/ws-incoming";
 
 /**

--- a/lib/test/http/custom-proxy-error.test.ts
+++ b/lib/test/http/custom-proxy-error.test.ts
@@ -1,10 +1,11 @@
 /*
   custom-proxy-error.test.ts: Example of using the custom `proxyError` event.
-  
+
 pnpm test ./custom-proxy-error.test.ts
 */
 
 import * as httpProxy from "../..";
+import * as http from "http";
 import getPort from "../get-port";
 import fetch from "node-fetch";
 
@@ -27,7 +28,7 @@ describe("Test proxying over HTTP with latency", () => {
       .listen(ports.proxy);
 
     proxy.on("error", (_err, _req, res) => {
-      res.writeHead(500, {
+      (res as http.ServerResponse).writeHead(500, {
         "Content-Type": "text/plain",
       });
       res.end(CUSTOM_ERROR);

--- a/lib/test/lib/http-proxy-passes-web-incoming.test.ts
+++ b/lib/test/lib/http-proxy-passes-web-incoming.test.ts
@@ -245,7 +245,7 @@ describe("#createProxyServer.web() using own http server", () => {
         proxyServer.close();
         expect(errReq).toEqual(req);
         expect(errRes).toEqual(res);
-        expect(err.code).toEqual("ECONNREFUSED");
+        expect((err as NodeJS.ErrnoException).code).toEqual("ECONNREFUSED");
         done();
       });
 
@@ -279,7 +279,7 @@ describe("#createProxyServer.web() using own http server", () => {
         proxyServer.close();
         expect(errReq).toEqual(req);
         expect(errRes).toEqual(res);
-        expect(err.code).toEqual("ECONNREFUSED");
+        expect((err as NodeJS.ErrnoException).code).toEqual("ECONNREFUSED");
         done();
       });
 
@@ -317,7 +317,7 @@ describe("#createProxyServer.web() using own http server", () => {
         expect(errReq).toEqual(req);
         expect(errRes).toEqual(res);
         expect(Date.now() - started).toBeGreaterThan(99);
-        expect(err.code).toEqual("ECONNRESET");
+        expect((err as NodeJS.ErrnoException).code).toEqual("ECONNRESET");
         done();
       });
 
@@ -362,7 +362,7 @@ describe("#createProxyServer.web() using own http server", () => {
         server.close();
         expect(errReq).toEqual(req);
         expect(errRes).toEqual(res);
-        expect(err.code).toEqual("ECONNRESET");
+        expect((err as NodeJS.ErrnoException).code).toEqual("ECONNRESET");
         doneOne();
       });
 

--- a/lib/test/lib/http-proxy-passes-web-incoming.test.ts
+++ b/lib/test/lib/http-proxy-passes-web-incoming.test.ts
@@ -213,7 +213,7 @@ describe("#createProxyServer.web() using own http server", () => {
     function requestHandler(req, res) {
       proxy.web(req, res, (err) => {
         proxyServer.close();
-        expect(err.code).toEqual("ECONNREFUSED");
+        expect((err as NodeJS.ErrnoException).code).toEqual("ECONNREFUSED");
         done();
       });
     }

--- a/lib/test/lib/http-proxy.test.ts
+++ b/lib/test/lib/http-proxy.test.ts
@@ -168,7 +168,7 @@ describe("#createProxyServer() method with error response", () => {
 
     proxy
       .on("error", (err) => {
-        expect(err.code).toEqual("ECONNREFUSED");
+        expect((err as NodeJS.ErrnoException).code).toEqual("ECONNREFUSED");
         proxy.close();
         done();
       })
@@ -198,7 +198,7 @@ describe("#createProxyServer setting the correct timeout value", () => {
       .listen(ports.proxy);
 
     proxy.on("error", (e) => {
-      expect(e.code).toEqual("ECONNRESET");
+      expect((e as NodeJS.ErrnoException).code).toEqual("ECONNRESET");
     });
 
     const source = http.createServer((_req, res) => {
@@ -327,7 +327,7 @@ describe("#createProxyServer using the ws-incoming passes", () => {
     });
 
     proxy.on("error", (err) => {
-      expect(err.code).toEqual("ECONNREFUSED");
+      expect((err as NodeJS.ErrnoException).code).toEqual("ECONNREFUSED");
       proxyServer.close();
       maybe_done();
     });

--- a/lib/test/middleware/body-decoder-middleware.test.ts
+++ b/lib/test/middleware/body-decoder-middleware.test.ts
@@ -34,7 +34,8 @@ describe("connect.bodyParser() middleware in http-proxy-3", () => {
     });
 
     // re-serialize parsed body before proxying.
-    proxy.on("proxyReq", (proxyReq, req, _res, _options) => {
+    proxy.on("proxyReq", (proxyReq, rawReq, _res, _options) => {
+      const req = rawReq as http.IncomingMessage & { body?: any };
       if (!req.body || !Object.keys(req.body).length) {
         return;
       }


### PR DESCRIPTION
This PR improves the types to have more compatibility with `@types/http-proxy`.

I've organized each commit to keep concerns separated. If you prefer a separate PR for each commit, I can create them one by one.

- 46b6f89c633eec8dcaaa2dc9c6efd22c1326b372: changed normal comments to jsdoc comments so that it is shown in the editor when hovered
- 108cfd55965a36eb5e03762c8fbb470ebcce1d37: added some jsdoc comments that exists in `@types/http-proxy`
- efcd8a3197df018d1c4b69e0b5978813ad36840a: added static methods that is supported by `http-proxy` for compat. 
- 6cba5193ea7c7c42bf852537c2db14f37361ca7f: exposed types from the root file so that the types can be imported from `http-proxy-3`. while it's possible to import from `http-proxy-3/dist/http-proxy`, I guess that's not expected to be done. `@types/http-proxy` exposes these types
- 0d6be3df970d0ecfb3f6132ea81df1bf4fa136d9: added stricter type for ProxyServer.web and ProxyServer.ws.
- 4c4a434a330214f62cfaf777f3263fd89157f014: added types for events
