### PR TITLE
fixes #11 Basic auth with authorization request header

### DIFF
--- a/lib/http-proxy/common.ts
+++ b/lib/http-proxy/common.ts
@@ -82,6 +82,7 @@ export function setupOutgoing(
   }
 
   if (options.auth) {
+    delete outgoing.headers.authorization;
     outgoing.auth = options.auth;
   }
 


### PR DESCRIPTION
The proxy should behave as configured (sending the basic auth to upstream) instead of forwarding the authorization header provided by the client