### PR TITLE
make tests pass on Windows

### DIFF
--- a/lib/test/websocket/websocket-load.test.ts
+++ b/lib/test/websocket/websocket-load.test.ts
@@ -115,7 +115,15 @@ async function loadTestWebsocketServerSerial({
   async function connectToProxy() {
     const req = http.request(options);
     req.end();
-    const [res] = await once(req, "upgrade");
+    const [event, [res]] = await Promise.race([
+      once(req, "upgrade").then(v => ['upgrade', v] as const),
+      once(req, "error").then(v => ['error', v] as const),
+    ])
+    if (event === 'error') {
+      // ignore ECONNREFUSED errors
+      if (res.code == 'ECONNREFUSED') return;
+      throw Error(res);
+    }
     res.socket.end();
   }
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,4 @@ onlyBuiltDependencies:
 overrides:
   brace-expansion@>=1.0.0 <=1.1.11: '>=1.1.12'
   brace-expansion@>=2.0.0 <=2.0.1: '>=2.0.2'
+shellEmulator: true


### PR DESCRIPTION
Made the tests pass on Windows.

- Enabled `shellEmulator` to make this env var work
   https://github.com/sagemathinc/http-proxy-3/blob/9246a0558eef488935252a0bc805c4d3cbb5ee1e/package.json#L61
- Added a code to ignore `ECONNREFUSED` errors that was happening on my machine