### PR TITLE
replace functions from `awaiting` package with builtin functions

### DIFF
--- a/lib/test/balancer/simple-balancer-with-websockets.test.ts
+++ b/lib/test/balancer/simple-balancer-with-websockets.test.ts
@@ -7,7 +7,7 @@ pnpm test ./simple-balancer-with-websockets.test.ts
 import * as http from "http";
 import * as httpProxy from "../..";
 import getPort from "../get-port";
-import { once } from "../wait";
+import { once } from "events";
 import fetch from "node-fetch";
 
 describe("A simple round-robin load balancer that supports websockets", () => {

--- a/lib/test/http/error-handling.test.ts
+++ b/lib/test/http/error-handling.test.ts
@@ -6,7 +6,6 @@ import * as httpProxy from "../..";
 import * as http from "http";
 import getPort from "../get-port";
 import log from "../log";
-import { callback } from "awaiting";
 import fetch from "node-fetch";
 
 const CUSTOM_ERROR = "There was an error proxying your request";
@@ -68,15 +67,14 @@ describe("Test proxying over HTTP with latency", () => {
         Upgrade: "websocket",
       },
     };
-    const f = (cb: any) => {
+    const err = await new Promise<Error>((resolve) => {
       const req = http.request(options);
       req.end();
       req.on("error", (err) => {
         log(`request error -- ${err}`);
-        cb(undefined, err);
+        resolve(err);
       });
-    };
-    const err = await callback(f);
+    });
     expect(err.message).toContain("socket hang up");
     expect(customWSErrorCalled).toBe(true);
   });

--- a/lib/test/http/server-sent-events.test.ts
+++ b/lib/test/http/server-sent-events.test.ts
@@ -9,7 +9,6 @@ import * as http from "http";
 import getPort from "../get-port";
 import { createSession } from "better-sse";
 import { EventSource } from "eventsource";
-import { callback } from "awaiting";
 import fetch from "node-fetch";
 
 describe("proxying server sent events over HTTP", () => {
@@ -60,26 +59,24 @@ describe("proxying server sent events over HTTP", () => {
     // These two tests leave open handles on node v18, so we disable them ONLY
     // with node v18.
     it("test receiving an SSE WITHOUT using the proxy", async () => {
-      const f = (cb: any) => {
+      const resp = await new Promise(resolve => {
         const sse = new EventSource(`http://localhost:${ports.http}/sse`);
         sse.addEventListener("message", ({ data }) => {
           sse.close();
-          cb(undefined, JSON.parse(data));
+          resolve(JSON.parse(data));
         });
-      };
-      const resp = await callback(f);
+      })
       expect(resp).toEqual("Hello world! - 1");
     });
 
     it("test receiving an SSE USING the proxy", async () => {
-      const f = (cb: any) => {
+      const resp = await new Promise(resolve => {
         const sse = new EventSource(`http://localhost:${ports.proxy}/sse`);
         sse.addEventListener("message", ({ data }) => {
           sse.close();
-          cb(undefined, JSON.parse(data));
+          resolve(JSON.parse(data));
         });
-      };
-      const resp = await callback(f);
+      });
       expect(resp).toEqual("Hello world! - 2");
     });
   }

--- a/lib/test/lib/http-proxy.test.ts
+++ b/lib/test/lib/http-proxy.test.ts
@@ -11,7 +11,8 @@ import * as net from "net";
 import WebSocket, { WebSocketServer } from "ws";
 import { Server } from "socket.io";
 import { io as socketioClient } from "socket.io-client";
-import wait, { once } from "../wait";
+import wait from "../wait";
+import { once } from "events";
 
 const ports: { [port: string]: number } = {};
 let portIndex = -1;

--- a/lib/test/wait.ts
+++ b/lib/test/wait.ts
@@ -1,9 +1,9 @@
-import { delay } from "awaiting";
+import { setTimeout } from "node:timers/promises";
 
 export default async function wait({ until }: { until: Function }) {
   let d = 5;
   while (!(await until())) {
-    await delay(d);
+    await setTimeout(d);
     d = Math.min(1000, d * 1.2);
   }
 }

--- a/lib/test/wait.ts
+++ b/lib/test/wait.ts
@@ -1,4 +1,4 @@
-import { callback, delay } from "awaiting";
+import { delay } from "awaiting";
 
 export default async function wait({ until }: { until: Function }) {
   let d = 5;
@@ -6,24 +6,4 @@ export default async function wait({ until }: { until: Function }) {
     await delay(d);
     d = Math.min(1000, d * 1.2);
   }
-}
-
-import type { EventEmitter } from "events";
-
-export async function once(obj: EventEmitter, event: string): Promise<any> {
-  if (obj == null) {
-    throw Error("once -- obj is undefined");
-  }
-  if (typeof obj.once != "function") {
-    throw Error("once -- obj.once must be a function");
-  }
-  let val: any[] = [];
-  function wait(cb: Function): void {
-    obj.once(event, function (...args): void {
-      val = args;
-      cb();
-    });
-  }
-  await callback(wait);
-  return val;
 }

--- a/lib/test/websocket/latent-websocket-proxy.test.ts
+++ b/lib/test/websocket/latent-websocket-proxy.test.ts
@@ -6,7 +6,7 @@ pnpm test latent-websocket-proxy.test.ts
 
 import * as httpProxy from "../..";
 import getPort from "../get-port";
-import { once } from "../wait";
+import { once } from "events";
 import http, { createServer } from "http";
 import { Server } from "socket.io";
 import { io as socketioClient } from "socket.io-client";

--- a/lib/test/websocket/simple-websocket-proxy.test.ts
+++ b/lib/test/websocket/simple-websocket-proxy.test.ts
@@ -15,7 +15,7 @@ import * as http from "http";
 import * as httpProxy from "../..";
 import log from "../log";
 import getPort from "../get-port";
-import { once } from "../wait";
+import { once } from "events";
 
 describe("Example of simple proxying of a WebSocket", () => {
   let ports: Record<'ws' | 'proxy', number>;

--- a/lib/test/websocket/standalone-websocket-proxy.test.ts
+++ b/lib/test/websocket/standalone-websocket-proxy.test.ts
@@ -6,7 +6,7 @@ pnpm test ./standalone-websocket-proxy.test.ts
 
 import * as httpProxy from "../..";
 import getPort from "../get-port";
-import { once } from "../wait";
+import { once } from "events";
 import http, { createServer } from "http";
 import { Server } from "socket.io";
 import { io as socketioClient } from "socket.io-client";

--- a/lib/test/websocket/websocket-load.test.ts
+++ b/lib/test/websocket/websocket-load.test.ts
@@ -7,7 +7,8 @@ pnpm test websocket-load.test.ts
 import * as http from "http";
 import * as httpProxy from "../..";
 import getPort from "../get-port";
-import wait, { once } from "../wait";
+import wait from "../wait";
+import { once } from "events";
 
 describe("Load testing proxying a WebSocket", () => {
   let ports: Record<'ws' | 'proxy', number>;

--- a/lib/test/websocket/websocket-proxy-websocket.test.ts
+++ b/lib/test/websocket/websocket-proxy-websocket.test.ts
@@ -17,7 +17,7 @@ import * as httpProxy from "../..";
 import getPort from "../get-port";
 import { Server } from "socket.io";
 import { io as socketioClient } from "socket.io-client";
-import { once } from "../wait";
+import { once } from "events";
 
 describe("Multilevel Proxying of a Websocket using Socket.io", () => {
   let ports: Record<'socketio' | 'inner' | 'outer', number>;

--- a/lib/test/websocket/websocket-proxy.test.ts
+++ b/lib/test/websocket/websocket-proxy.test.ts
@@ -13,7 +13,8 @@ that no sockets leak.
 import * as httpProxy from "../..";
 import log from "../log";
 import getPort from "../get-port";
-import wait, { once } from "../wait";
+import wait from "../wait";
+import { once } from "events";
 import { createServer } from "http";
 import { Server } from "socket.io";
 import { io as socketioClient } from "socket.io-client";

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "@types/ws": "^8.18.1",
     "async": "^3.2.6",
     "auto-changelog": "^2.5.0",
-    "awaiting": "^3.0.0",
     "better-sse": "^0.14.1",
     "body-parser": "^2.2.0",
     "compression": "^1.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,9 +61,6 @@ importers:
       auto-changelog:
         specifier: ^2.5.0
         version: 2.5.0
-      awaiting:
-        specifier: ^3.0.0
-        version: 3.0.0
       better-sse:
         specifier: ^0.14.1
         version: 0.14.1
@@ -531,10 +528,6 @@ packages:
     resolution: {integrity: sha512-UTnLjT7I9U2U/xkCUH5buDlp8C7g0SGChfib+iDrJkamcj5kaMqNKHNfbKJw1kthJUq8sUo3i3q2S6FzO/l/wA==}
     engines: {node: '>=8.3'}
     hasBin: true
-
-  awaiting@3.0.0:
-    resolution: {integrity: sha512-19i4G7Hjxj9idgMlAM0BTRII8HfvsOdlr4D9cf3Dm1MZhvcKjBpzY8AMNEyIKyi+L9TIK15xZatmdcPG003yww==}
-    engines: {node: '>=7.6.x'}
 
   babel-jest@29.7.0:
     resolution: {integrity: sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==}
@@ -2407,8 +2400,6 @@ snapshots:
       semver: 7.7.1
     transitivePeerDependencies:
       - encoding
-
-  awaiting@3.0.0: {}
 
   babel-jest@29.7.0(@babel/core@7.27.1):
     dependencies:


### PR DESCRIPTION
Replaced functions from `awaiting` package with builtin functions as builtin functions has types while `awaiting` package does not have types.
