### PR TITLE
fix: target search params are missing when target is a URL

### DIFF
--- a/lib/http-proxy/common.ts
+++ b/lib/http-proxy/common.ts
@@ -112,7 +112,7 @@ export function setupOutgoing(
 
   // target if defined is a URL object so has attribute "pathname", not "path".
   const targetPath =
-    target && options.prependPath !== false && 'pathname' in target ? getPath(target.pathname) : "/";
+    target && options.prependPath !== false && 'pathname' in target ? getPath(`${target.pathname}${target.search ?? ""}`) : "/";
 
   let outgoingPath = options.toProxy ? req.url : getPath(req.url);
 

--- a/lib/test/lib/http-proxy-common.test.ts
+++ b/lib/test/lib/http-proxy-common.test.ts
@@ -292,6 +292,33 @@ describe("#setupOutgoing", () => {
     expect(outgoing.path).toEqual("/forward/src?f=1&s=1");
   });
 
+  it("target path is URL and has query string", () => {
+    const outgoing: any = {};
+    setupOutgoing(
+      outgoing,
+      {
+        target: new URL("http://dummy.org/some-path?a=1&b=2"),
+      },
+      { url: "/src?s=1" },
+    );
+
+    expect(outgoing.path).toEqual("/some-path/src?a=1&b=2&s=1");
+  });
+
+  it("target path is URL and has query string with ignorePath", () => {
+    const outgoing: any = {};
+    setupOutgoing(
+      outgoing,
+      {
+        target: new URL("http://dummy.org/some-path?a=1&b=2"),
+        ignorePath: true,
+      },
+      { url: "/src?s=1" },
+    );
+
+    expect(outgoing.path).toEqual("/some-path?a=1&b=2");
+  });
+
   //
   // This is the proper failing test case for the common.join problem
   //


### PR DESCRIPTION
As mentioned in #16, when the target has search parameters, they somehow go missing when `ignorePath` is set to true. Turns out, that wasn't the bug, and this happens anytime target is a URL (either passed in as a string, or URL when configuring the proxy).