### PR TITLE
feat: support empty `req.url`

### DIFF
--- a/lib/http-proxy/common.ts
+++ b/lib/http-proxy/common.ts
@@ -268,6 +268,9 @@ function hasPort(host: string): boolean {
 }
 
 function getPath(url?: string): string {
+  if (url === '' || url?.startsWith('?')) {
+    return url
+  }
   const u = toURL(url);
   return `${u.pathname ?? ""}${u.search ?? ""}`;
 }

--- a/lib/test/http/empty-req-url.test.ts
+++ b/lib/test/http/empty-req-url.test.ts
@@ -1,0 +1,52 @@
+import express from "express";
+import getPort from "../get-port";
+import ProxyServer, { createServer } from "../..";
+import http from "node:http";
+
+describe("test empty req.url", () => {
+  let port: number, server: http.Server;
+
+  it("create a simple http server", async () => {
+    port = await getPort();
+    const app = express();
+
+    app.get("/test", (req, res, next) => {
+      if (req.path !== "/test") return next();
+      res.send("Test Page!: " + JSON.stringify(req.query));
+    });
+
+    server = app.listen(port);
+  });
+
+  let proxy: ProxyServer, httpServer: http.Server;
+  let proxyPort: number;
+  it("create a proxy server", async () => {
+    proxy = createServer();
+    proxy.on("error", (err, _req, res) => {
+      console.error("Proxy error:", err);
+      res.end("Something went wrong.");
+    });
+    httpServer = http.createServer((req, res) => {
+      req.url = '' + new URL(`http://example.com${req.url}`).search;
+      proxy.web(req, res, { target: `http://localhost:${port}/test` });
+    });
+
+    proxyPort = await getPort();
+    httpServer.listen(proxyPort);
+  });
+
+  const getProxy = async (url: string) => {
+    return await (await fetch(`http://localhost:${proxyPort}${url}`)).text();
+  };
+
+  it("get using the proxy", async () => {
+    expect(await getProxy("")).toBe("Test Page!: {}");
+    expect(await getProxy("?foo")).toBe("Test Page!: {\"foo\":\"\"}");
+    expect(await getProxy("?foo=bar")).toBe("Test Page!: {\"foo\":\"bar\"}");
+  });
+
+  it("clean up", () => {
+    server.close();
+    httpServer.close();
+  });
+});


### PR DESCRIPTION
In Vite, we support `rewrite` option, which allows users to change `req.url` before it is passed to `http-proxy-3`.
Some users were setting `req.url: ''` with that option.
With `http-proxy`, when `target` is `http://example.com/test`, the request was proxied to `http://example.com/test`.
But with `http-proxy-3`, the request is proxied to ``http://example.com/test/` (has a trailing slash).

This PR fixes that behavior difference by adding some code to handle them.

Since `req.url: ''` doesn't happen normally, I'm also fine with patching this on Vite side (https://github.com/vitejs/vite/pull/20679).
