### PR TITLE
fix: use invalid domain as base in `toURL`

### DIFF
--- a/lib/http-proxy/common.ts
+++ b/lib/http-proxy/common.ts
@@ -291,10 +291,10 @@ export function toURL(url: URL | urllib.Url | ProxyTargetDetailed | string | und
   if (url.startsWith("//")) {
     // special case -- this would be viewed as a this is a "network-path reference",
     // so we explicitly prefix with our http schema.  See
-    url = `http://dummy.org${url}`;
+    url = `http://base.invalid${url}`;
   }
   // urllib.Url is deprecated but we support it by converting to URL
-  return new URL(url, "http://dummy.org");
+  return new URL(url, "http://base.invalid");
 }
 
 // vendor simplified version of https://www.npmjs.com/package/requires-port to

--- a/lib/test/http/reverse-proxy.test.ts
+++ b/lib/test/http/reverse-proxy.test.ts
@@ -26,7 +26,7 @@ describe("Reverse proxying -- create a server that...", () => {
     server = http
       .createServer((req, res) => {
         log("Receiving reverse proxy request for:", req.url);
-        const urlObj = new URL(req.url ?? "", "http://dummy.org");
+        const urlObj = new URL(req.url ?? "", "http://base.invalid");
         const target = urlObj.origin;
         proxy.web(req, res, { target, secure: false });
       })

--- a/lib/test/lib/http-proxy-common.test.ts
+++ b/lib/test/lib/http-proxy-common.test.ts
@@ -298,7 +298,7 @@ describe("#setupOutgoing", () => {
     setupOutgoing(
       outgoing,
       {
-        target: new URL("http://dummy.org/some-path?a=1&b=2"),
+        target: new URL("http://base.invalid/some-path?a=1&b=2"),
       },
       { url: "/src?s=1" },
     );
@@ -311,7 +311,7 @@ describe("#setupOutgoing", () => {
     setupOutgoing(
       outgoing,
       {
-        target: new URL("http://dummy.org/some-path?a=1&b=2"),
+        target: new URL("http://base.invalid/some-path?a=1&b=2"),
         ignorePath: true,
       },
       { url: "/src?s=1" },
@@ -329,7 +329,7 @@ describe("#setupOutgoing", () => {
     setupOutgoing(
       outgoing,
       {
-        target: new URL("http://sometarget.com:80", "http://dummy.org"),
+        target: new URL("http://sometarget.com:80", "http://base.invalid"),
         toProxy: true,
       },
       { url: google },
@@ -344,7 +344,7 @@ describe("#setupOutgoing", () => {
     setupOutgoing(
       outgoing,
       {
-        target: new URL("http://sometarget.com:80", "http://dummy.org"),
+        target: new URL("http://sometarget.com:80", "http://base.invalid"),
         toProxy: true,
       },
       { url: google },
@@ -359,7 +359,7 @@ describe("#setupOutgoing", () => {
     setupOutgoing(
       outgoing,
       {
-        target: new URL("http://sometarget.com:80", "http://dummy.org"),
+        target: new URL("http://sometarget.com:80", "http://base.invalid"),
         toProxy: true,
       },
       { url: google },
@@ -375,7 +375,7 @@ describe("#setupOutgoing", () => {
       setupOutgoing(
         outgoing,
         {
-          target: new URL(myEndpoint, "http://dummy.org"),
+          target: new URL(myEndpoint, "http://base.invalid"),
           ignorePath: true,
         },
         { url: "/more/crazy/pathness" },
@@ -390,7 +390,7 @@ describe("#setupOutgoing", () => {
       setupOutgoing(
         outgoing,
         {
-          target: new URL(myEndpoint, "http://dummy.org"),
+          target: new URL(myEndpoint, "http://base.invalid"),
           ignorePath: true,
           prependPath: false,
         },
@@ -408,7 +408,7 @@ describe("#setupOutgoing", () => {
       setupOutgoing(
         outgoing,
         {
-          target: new URL(myEndpoint, "http://dummy.org"),
+          target: new URL(myEndpoint, "http://base.invalid"),
           changeOrigin: true,
         },
         { url: "/" },
@@ -475,7 +475,7 @@ describe("#setupOutgoing", () => {
     setupOutgoing(
       outgoing,
       {
-        target: new URL("https://whooooo.com", "http://dummy.org"),
+        target: new URL("https://whooooo.com", "http://base.invalid"),
         method: "POST",
       },
       { method: "GET", url: "" },

--- a/lib/test/lib/http-proxy-passes-web-incoming.test.ts
+++ b/lib/test/lib/http-proxy-passes-web-incoming.test.ts
@@ -626,7 +626,7 @@ describe("#followRedirects", () => {
     const source = http
       .createServer((req, res) => {
         if (
-          new URL(req.url ?? "", "http://dummy.org").pathname === "/redirect"
+          new URL(req.url ?? "", "http://base.invalid").pathname === "/redirect"
         ) {
           res.writeHead(200, { "Content-Type": "text/plain" });
           res.end("ok");


### PR DESCRIPTION
I don't think it's possible to actually exploit this. But it's still better to avoid a real domain here.

I didn't reject a URL without the base part as I guess this function need to accept path-only URLs (e.g. `/foo`).

fixes #31
