### PR TITLE
feat: add incoming http2 support

### DIFF
--- a/lib/http-proxy/common.ts
+++ b/lib/http-proxy/common.ts
@@ -27,6 +27,13 @@ export interface Outgoing extends Outgoing0 {
 // See https://github.com/http-party/node-http-proxy/issues/1647
 const HEADER_BLACKLIST = "trailer";
 
+const HTTP2_HEADER_BLACKLIST = [
+  ':method',
+  ':path',
+  ':scheme',
+  ':authority',
+]
+
 // setupOutgoing -- Copies the right headers from `options` and `req` to
 // `outgoing` which is then used to fire the proxied request by calling
 // http.request or https.request with outgoing as input.
@@ -78,6 +85,12 @@ export function setupOutgoing(
     if (HEADER_BLACKLIST == header.toLowerCase()) {
       delete outgoing.headers[header];
       break;
+    }
+  }
+
+  if (req.httpVersionMajor > 1) {
+    for (const header of HTTP2_HEADER_BLACKLIST) {
+      delete outgoing.headers[header];
     }
   }
 

--- a/lib/http-proxy/passes/web-outgoing.ts
+++ b/lib/http-proxy/passes/web-outgoing.ts
@@ -143,6 +143,10 @@ export function writeHeaders(
 
   for (const key0 in proxyRes.headers) {
     let key = key0;
+    if (_req.httpVersionMajor > 1 && key === "connection") {
+      // don't send connection header to http2 client
+      continue;
+    }
     const header = proxyRes.headers[key];
     if (preserveHeaderKeyCase && rawHeaderKeyMap) {
       key = rawHeaderKeyMap[key] ?? key;
@@ -158,11 +162,10 @@ export function writeStatusCode(
   proxyRes: ProxyResponse,
 ) {
   // From Node.js docs: response.writeHead(statusCode[, statusMessage][, headers])
-  if (proxyRes.statusMessage) {
-    res.statusCode = proxyRes.statusCode!;
+  res.statusCode = proxyRes.statusCode!;
+
+  if (proxyRes.statusMessage && _req.httpVersionMajor === 1) {
     res.statusMessage = proxyRes.statusMessage;
-  } else {
-    res.statusCode = proxyRes.statusCode!;
   }
 }
 

--- a/lib/test/http/proxy-http2-to-http.test.ts
+++ b/lib/test/http/proxy-http2-to-http.test.ts
@@ -1,0 +1,68 @@
+/*
+pnpm test proxy-https-to-http.test.ts
+*/
+
+import * as http from "node:http";
+import * as httpProxy from "../..";
+import getPort from "../get-port";
+import { join } from "node:path";
+import { readFile } from "node:fs/promises";
+import fetch from "node-fetch";
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { Agent, setGlobalDispatcher } from "undici";
+
+setGlobalDispatcher(new Agent({
+  allowH2: true
+}));
+
+
+const fixturesDir = join(__dirname, "..", "fixtures");
+
+describe("Basic example of proxying over HTTPS to a target HTTP server", () => {
+  let ports: Record<'http' | 'proxy', number>;
+  beforeAll(async () => {
+    ports = { http: await getPort(), proxy: await getPort() };
+  });
+
+  const servers: any = {};
+
+  it("Create the target HTTP server", async () => {
+    servers.http = http
+      .createServer((_req, res) => {
+        res.writeHead(200, { "Content-Type": "text/plain" });
+        res.write("hello http over https\n");
+        res.end();
+      })
+      .listen(ports.http);
+  });
+
+  it("Create the HTTPS proxy server", async () => {
+    servers.proxy = httpProxy
+      .createServer({
+        target: {
+          host: "localhost",
+          port: ports.http,
+        },
+        ssl: {
+          key: await readFile(join(fixturesDir, "agent2-key.pem"), "utf8"),
+          cert: await readFile(join(fixturesDir, "agent2-cert.pem"), "utf8"),
+        },
+      })
+      .listen(ports.proxy);
+  });
+
+  it("Use fetch to test non-https server", async () => {
+    const r = await (await fetch(`http://localhost:${ports.http}`)).text();
+    expect(r).toContain("hello http over https");
+  });
+
+  it("Use fetch to test the ACTUAL https server", async () => {
+    const r = await (await fetch(`https://localhost:${ports.proxy}`)).text();
+    expect(r).toContain("hello http over https");
+  });
+
+  afterAll(async () => {
+    // cleans up
+    Object.values(servers).map((x: any) => x?.close());
+  });
+});

--- a/lib/test/http/proxy-http2-to-https.test.ts
+++ b/lib/test/http/proxy-http2-to-https.test.ts
@@ -1,0 +1,69 @@
+/*
+pnpm test proxy-https-to-https.test.ts
+
+*/
+
+import * as https from "node:https";
+import * as httpProxy from "../..";
+import getPort from "../get-port";
+import { join } from "node:path";
+import { readFile } from "node:fs/promises";
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { Agent, setGlobalDispatcher } from "undici";
+
+setGlobalDispatcher(new Agent({
+  allowH2: true
+}));
+
+const fixturesDir = join(__dirname, "..", "fixtures");
+
+describe("Basic example of proxying over HTTPS to a target HTTPS server", () => {
+  let ports: Record<'https' | 'proxy', number>;
+  beforeAll(async () => {
+    // Gets ports
+    ports = { https: await getPort(), proxy: await getPort() };
+  });
+
+  const servers: any = {};
+  let ssl: { key: string; cert: string };
+
+  it("Create the target HTTPS server", async () => {
+    ssl = {
+      key: await readFile(join(fixturesDir, "agent2-key.pem"), "utf8"),
+      cert: await readFile(join(fixturesDir, "agent2-cert.pem"), "utf8"),
+    };
+    servers.https = https
+      .createServer(ssl, (_req, res) => {
+        res.writeHead(200, { "Content-Type": "text/plain" });
+        res.write("hello over https\n");
+        res.end();
+      })
+      .listen(ports.https);
+  });
+
+  it("Create the HTTPS proxy server", async () => {
+    servers.proxy = httpProxy
+      .createServer({
+        target: `https://localhost:${ports.https}`,
+        ssl,
+        // without secure false, clients will fail and this is broken:
+        secure: false,
+      })
+      .listen(ports.proxy);
+  });
+
+  it("Use fetch to test direct non-proxied https server", async () => {
+    const r = await (await fetch(`https://localhost:${ports.https}`)).text();
+    expect(r).toContain("hello over https");
+  });
+
+  it("Use fetch to test the proxy server", async () => {
+    const r = await (await fetch(`https://localhost:${ports.proxy}`)).text();
+    expect(r).toContain("hello over https");
+  });
+
+  afterAll(async () => {
+    // cleanup
+    Object.values(servers).map((x: any) => x?.close());
+  });
+});

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "socket.io": "^4.8.1",
     "socket.io-client": "^4.8.1",
     "typescript": "^5.8.3",
+    "undici": "^7.16.0",
     "vitest": "^3.2.4",
     "ws": "^8.18.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,6 +103,9 @@ importers:
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
+      undici:
+        specifier: ^7.16.0
+        version: 7.16.0
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.15.12)(@vitest/browser@3.2.4)
@@ -1199,6 +1202,10 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@7.16.0:
+    resolution: {integrity: sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==}
+    engines: {node: '>=20.18.1'}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -2420,6 +2427,8 @@ snapshots:
     optional: true
 
   undici-types@6.21.0: {}
+
+  undici@7.16.0: {}
 
   unpipe@1.0.0: {}
 


### PR DESCRIPTION
This is a first step towards http2 support (#2 ).

This PR allows incoming http2 requests towards the proxy. This means the proxy server can accept http2 requests, but forwards them as http1 requests towards the target server. 

The primary motivation and use case for this PR is that currently vite falls back to http1, when proxy is set, because the proxy server can't handle http2 requests (see https://github.com/vitejs/vite/issues/4184). With this PR, vite can send its own responses as http2 and forward http2 requests to the proxy server. The proxy server forwards the request as http1, but answers the http2 request. I tested this manually.

For full http2 support, the proxy server should forward the request as http2, if possible, but this will require a much larger effort, because the https client currently used can't make h2 requests and the http2 client can't make http1 requests. So we would have to either probe the target server to see if it supports h2 requests and make a http2 connection, for which the API would be slightly different, or evaluate the use of undicis fetch, which can make h2 requests and fall back to http1 transparently. But both approaches are outside the scope of this PR. 

