### PR TITLE
fix: use `any` for `dispatcher` when `lib: 'dom'` is used

### DIFF
--- a/lib/http-proxy/index.ts
+++ b/lib/http-proxy/index.ts
@@ -101,7 +101,11 @@ export interface ServerOptions {
   fetch?: boolean | FetchOptions;
 }
 
-export type Dispatcher = RequestInit["dispatcher"];
+// use `any` when `lib: "dom"` is included in tsconfig.json,
+// as dispatcher property does not exist in RequestInit in that case
+export type Dispatcher = (typeof globalThis extends { onmessage: any }
+  ? any
+  : RequestInit)["dispatcher"];
 
 export interface FetchOptions {
   /** Allow custom dispatcher */


### PR DESCRIPTION
`@types/node` uses `typeof globalThis extends { onmessage: any } ? {} : import("undici-types").RequestInit;` for the type of `RequestInit` (this is to avoid the type conflict between RequestInit in dom and undici).
So if `lib: 'dom'` is included in `tsconfig.json`, an error is output by TypeScript for `RequestInit["dispatcher"]`.
https://github.com/vitejs/vite/actions/runs/19419498249/job/55554030486#step:9:22

This PR fixes that error by using `any` for `dispatcher` when `lib: 'dom'` is used.
