### PR TITLE
types: Allow Partial<URL> in ProxyTargetUrl type

### DIFF
--- a/lib/http-proxy/common.ts
+++ b/lib/http-proxy/common.ts
@@ -318,7 +318,7 @@ function getPath(url?: string): string {
 }
 
 export function toURL(
-  url: URL | urllib.Url | ProxyTargetDetailed | string | undefined,
+  url: Partial<URL> | urllib.Url | ProxyTargetDetailed | string | undefined,
 ): URL {
   if (url instanceof URL) {
     return url;

--- a/lib/http-proxy/index.ts
+++ b/lib/http-proxy/index.ts
@@ -27,7 +27,7 @@ export interface ProxyTargetDetailed {
 export type ProxyType = "ws" | "web";
 export type ProxyTarget = ProxyTargetUrl | ProxyTargetDetailed;
 export type ProxyTargetUrl =
-  | URL
+  | Partial<URL>
   | string
   | { port: number; host: string; protocol?: string };
 


### PR DESCRIPTION
Widening the `ProxyTargetUrl` type for migration to http-proxy-3 (https://github.com/chimurai/http-proxy-middleware/pull/1159)

Current `ProxyTargetUrl` is too strict and won't accept Express request type (`Request<ParamsDictionary....`) or other custom request types from server/frameworks

<img width="1042" height="413" alt="image" src="https://github.com/user-attachments/assets/556b2b7f-88ce-4f90-9e5b-2d51b9e118ab" />

With Partial<URL> Express' Request type will flow through the generic types
<img width="1042" height="223" alt="image" src="https://github.com/user-attachments/assets/d30f363a-ac5f-4dc9-9725-c7eda08f5bb0" />



This is blocker for the migration to http-proxy-3 in https://github.com/chimurai/http-proxy-middleware/pull/1159


Related to TypeScript Generics:
- https://github.com/sagemathinc/http-proxy-3/pull/20
- `http-proxy` https://github.com/DefinitelyTyped/DefinitelyTyped/blob/e138fcfb80801ff42ee291de4fcddbc6cbe7e9aa/types/http-proxy/index.d.ts#L143 (with `Partial<URL>` implementation)

