### PR TITLE
fix: strip IPv6 brackets from outgoing.hostname to fix ENOTFOUND

### DIFF
--- a/lib/http-proxy/common.ts
+++ b/lib/http-proxy/common.ts
@@ -79,6 +79,16 @@ export function setupOutgoing(
     outgoing[e] = target[e];
   }
 
+  // Fix for IPv6: the WHATWG URL spec serialises IPv6 hostnames with square
+  // brackets (e.g. new URL("http://[::1]/").hostname === "[::1]"), but
+  // Node.js dns.lookup / getaddrinfo require a bare address without brackets.
+  // Passing the bracketed form causes an ENOTFOUND error even for valid
+  // addresses.  outgoing.host is already in the correct "[addr]:port" format
+  // for HTTP Host headers and is left unchanged.
+  if (outgoing.hostname?.startsWith("[") && outgoing.hostname.endsWith("]")) {
+    outgoing.hostname = outgoing.hostname.slice(1, -1);
+  }
+
   outgoing.method = options.method || req.method;
   outgoing.headers = { ...req.headers };
   if (req.headers?.[":authority"]) {
@@ -306,7 +316,14 @@ export function rewriteCookieProperty(
 
 // Check the host and see if it potentially has a port in it (keep it simple)
 function hasPort(host: string): boolean {
-  return !!~host.indexOf(":");
+  // IPv6 addresses in bracket notation: a port is present only after ']',
+  // e.g. "[::1]:8080" has a port but "[::1]" does not.
+  // A plain indexOf(":") would incorrectly match colons inside the IPv6 address.
+  if (host.startsWith("[")) {
+    const closingBracket = host.indexOf("]");
+    return closingBracket !== -1 && host.length > closingBracket + 1;
+  }
+  return host.includes(":");
 }
 
 function getPath(url?: string): string {

--- a/lib/test/http/ipv6-proxy.test.ts
+++ b/lib/test/http/ipv6-proxy.test.ts
@@ -1,0 +1,82 @@
+/*
+Test proxying to an IPv6 target.
+
+Regression test for https://github.com/sagemathinc/http-proxy-3/issues/52:
+WHATWG URL.host for IPv6 targets includes brackets and the port
+(e.g. "[::1]:8080"), which caused Node.js to pass "[::1]" (brackets included)
+to getaddrinfo, failing with ENOTFOUND.
+
+DEVELOPMENT:
+
+pnpm test ipv6-proxy.test.ts
+*/
+
+import * as http from "node:http";
+import * as httpProxy from "../..";
+import getPort from "../get-port";
+import fetch from "node-fetch";
+import { describe, it, expect } from "vitest";
+
+// Listen on IPv6 loopback and return the assigned port.
+async function listenIPv6(server: http.Server): Promise<number> {
+  return new Promise((resolve, reject) => {
+    server.listen(0, "::1", () => {
+      const address = server.address();
+      if (typeof address === "object" && address !== null) {
+        resolve(address.port);
+      } else {
+        reject(new Error("Failed to get IPv6 port"));
+      }
+    });
+    server.on("error", reject);
+  });
+}
+
+describe("proxying to an IPv6 target", () => {
+  it("forwards requests to an IPv6 backend without ENOTFOUND", async () => {
+    const proxyPort = await getPort();
+
+    const target = http.createServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "text/plain" });
+      res.end("ok from ipv6 backend");
+    });
+    const targetPort = await listenIPv6(target);
+
+    const proxy = httpProxy
+      .createServer({ target: `http://[::1]:${targetPort}` })
+      .listen(proxyPort);
+
+    const body = await (await fetch(`http://localhost:${proxyPort}`)).text();
+    expect(body).toBe("ok from ipv6 backend");
+
+    proxy.close();
+    target.close();
+  });
+
+  it("sets the correct Host header with changeOrigin and a non-standard port", async () => {
+    const proxyPort = await getPort();
+
+    let receivedHost: string | undefined;
+    const target = http.createServer((req, res) => {
+      receivedHost = req.headers.host;
+      res.writeHead(200);
+      res.end();
+    });
+    const targetPort = await listenIPv6(target);
+
+    const proxy = httpProxy
+      .createServer({
+        target: `http://[::1]:${targetPort}`,
+        changeOrigin: true,
+      })
+      .listen(proxyPort);
+
+    await fetch(`http://localhost:${proxyPort}`);
+
+    // Host header must be "[::1]:port" for non-standard ports (RFC 2732).
+    expect(receivedHost).toBe(`[::1]:${targetPort}`);
+
+    proxy.close();
+    target.close();
+  });
+});


### PR DESCRIPTION
## Context

I'm not a TypeScript developer — I'm a Site Reliability Engineer who ran into this bug while operating a JupyterHub deployment on an IPv6-only Kubernetes cluster. Every time a user tried to launch a notebook, the proxy would return a 503 with `getaddrinfo ENOTFOUND [2a05:...]` in the logs. After digging into the stack (KubeSpawner → configurable-http-proxy → http-proxy-3), I traced the root cause to this library and found the open issue #52.

This fix and the accompanying test were developed with AI assistance (Claude). I've done my best to make sure the fix is correct and minimal, but please review carefully — I'm happy to iterate.

## Problem

When proxying to an IPv6 target (e.g. `http://[::1]:8888` or `http://[2a05:d018::1]:8888`), the proxy fails with:

```
Error: getaddrinfo ENOTFOUND [::1]
```

The WHATWG URL spec serialises IPv6 hostnames **with square brackets**:

```js
new URL("http://[::1]:8888/").hostname // → "[::1]"  (brackets included)
new URL("http://[::1]:8888/").host     // → "[::1]:8888"
```

`setupOutgoing` copies `target.hostname` (= `"[::1]"`) directly to `outgoing.hostname`, which is then passed to `http.request`. Node.js forwards this value to `dns.lookup` / `getaddrinfo`, which expects a **bare** address (`::1`), not the bracketed form — hence ENOTFOUND.

This is the root cause reported in #52.

## Fix

After copying the target properties, strip brackets from `outgoing.hostname` when present. `outgoing.host` (`"[::1]:8888"`) is already in the correct [RFC 2732](https://www.rfc-editor.org/rfc/rfc2732) format for HTTP `Host` headers and is left unchanged.

Also fixes `hasPort()` which used `indexOf(":")` and therefore always returned `true` for any IPv6 address (even without a port), because IPv6 addresses contain colons. The correct check looks for characters **after** the closing `]`.

## Tests

New test file `lib/test/http/ipv6-proxy.test.ts` covering:

1. Basic forwarding to an IPv6 backend (the ENOTFOUND regression)
2. `changeOrigin: true` — verifies the `Host` header is `[::1]:port` (RFC 2732 bracket notation) for non-standard ports

Full test suite: **302 passed, 0 failures**.

## Real-world context

Triggered in production on an IPv6-only Kubernetes cluster: KubeSpawner registers notebook pods using `pod.status.podIP` (an IPv6 address), configurable-http-proxy (JupyterHub) receives routes as `http://[ipv6]:port` and forwards them through `http-proxy-3`, hitting this bug.

Fixes #52