### PR TITLE
feat: support function-based dynamic target for ServerOptions

### DIFF
--- a/lib/http-proxy/index.ts
+++ b/lib/http-proxy/index.ts
@@ -30,6 +30,9 @@ export type ProxyTargetUrl =
   | URL
   | string
   | { port: number; host: string; protocol?: string };
+export type ProxyTargetFunction = (
+  req: http.IncomingMessage,
+) => ProxyTarget;
 
 export type NormalizeProxyTarget<T extends ProxyTargetUrl> =
   | Exclude<T, string>
@@ -40,8 +43,8 @@ export interface ServerOptions {
   // actually proxying is called.  However, they can be missing when creating the
   // proxy server in the first place!  E.g., you could make a proxy server P with
   // no options, then use P.web(req,res, {target:...}).
-  /** URL string to be parsed with the url module. */
-  target?: ProxyTarget;
+  /** URL string to be parsed with the url module, or a function returning a ProxyTarget. */
+  target?: ProxyTarget | ProxyTargetFunction;
   /** URL string to be parsed with the url module or a URL object. */
   forward?: ProxyTargetUrl;
   /** Object to be passed to http(s).request. */
@@ -408,6 +411,10 @@ export class ProxyServer<
 
         if (args[counter] instanceof Buffer) {
           head = args[counter];
+        }
+
+        if (typeof requestOptions.target === "function") {
+          requestOptions.target = requestOptions.target(req);
         }
 
         for (const e of ["target", "forward"] as const) {

--- a/lib/http-proxy/index.ts
+++ b/lib/http-proxy/index.ts
@@ -414,7 +414,12 @@ export class ProxyServer<
         }
 
         if (typeof requestOptions.target === "function") {
-          requestOptions.target = requestOptions.target(req);
+          try {
+            requestOptions.target = requestOptions.target(req);
+          } catch (err) {
+            this.emit("error", err as TError, req, res);
+            return;
+          }
         }
 
         for (const e of ["target", "forward"] as const) {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -2,6 +2,7 @@ import {
   type ErrorCallback,
   ProxyServer,
   type ProxyTarget,
+  type ProxyTargetFunction,
   type ProxyTargetUrl,
   type ServerOptions,
 } from './http-proxy/index';
@@ -9,6 +10,7 @@ export {
   ProxyServer,
   type ServerOptions,
   type ProxyTarget,
+  type ProxyTargetFunction,
   type ProxyTargetUrl,
   type ErrorCallback,
 };

--- a/lib/test/http/dynamic-target.test.ts
+++ b/lib/test/http/dynamic-target.test.ts
@@ -1,0 +1,190 @@
+/*
+Test dynamic target using a function that returns ProxyTarget
+
+DEVELOPMENT:
+
+pnpm test dynamic-target.test.ts
+*/
+
+import * as http from "node:http";
+import * as httpProxy from "../..";
+import getPort from "../get-port";
+import fetch from "node-fetch";
+import { describe, it, expect, afterAll, beforeAll } from "vitest";
+
+async function setup() {
+  const port1 = await getPort();
+  const port2 = await getPort();
+  const proxyPort = await getPort();
+
+  const target1 = http.createServer((_req, res) => {
+    res.writeHead(200, { "Content-Type": "text/plain" });
+    res.write("target1 responded");
+    res.end();
+  });
+  target1.listen(port1);
+
+  const target2 = http.createServer((_req, res) => {
+    res.writeHead(200, { "Content-Type": "text/plain" });
+    res.write("target2 responded");
+    res.end();
+  });
+  target2.listen(port2);
+
+  const proxy = httpProxy
+    .createServer({
+      target: (req: http.IncomingMessage) => {
+        if (req.url?.startsWith("/app2")) {
+          return `http://localhost:${port2}`;
+        }
+        return `http://localhost:${port1}`;
+      },
+    })
+    .listen(proxyPort);
+  proxy.on("error", (_e) => {});
+
+  return { proxy, target1, target2, port1, port2, proxyPort };
+}
+
+describe("dynamic target function", () => {
+  let servers: Awaited<ReturnType<typeof setup>>;
+
+  beforeAll(async () => {
+    servers = await setup();
+  });
+
+  afterAll(() => {
+    servers.proxy.close();
+    servers.target1.close();
+    servers.target2.close();
+  });
+
+  it("routes to target1 for /app1 path", async () => {
+    const res = await fetch(`http://localhost:${servers.proxyPort}/app1`);
+    const body = await res.text();
+    expect(body).toBe("target1 responded");
+  });
+
+  it("routes to target2 for /app2 path", async () => {
+    const res = await fetch(`http://localhost:${servers.proxyPort}/app2`);
+    const body = await res.text();
+    expect(body).toBe("target2 responded");
+  });
+
+  it("routes to target1 for root path", async () => {
+    const res = await fetch(`http://localhost:${servers.proxyPort}/`);
+    const body = await res.text();
+    expect(body).toBe("target1 responded");
+  });
+});
+
+describe("dynamic target with per-request override", () => {
+  it("per-request target overrides the function target", async () => {
+    const port1 = await getPort();
+    const port2 = await getPort();
+    const proxyPort = await getPort();
+
+    const target1 = http.createServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "text/plain" });
+      res.write("target1");
+      res.end();
+    });
+    target1.listen(port1);
+
+    const target2 = http.createServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "text/plain" });
+      res.write("target2");
+      res.end();
+    });
+    target2.listen(port2);
+
+    const proxy = httpProxy
+      .createServer({
+        target: (_req: http.IncomingMessage) => `http://localhost:${port1}`,
+      })
+      .listen(proxyPort);
+    proxy.on("error", (_e) => {});
+
+    const res = await fetch(`http://localhost:${proxyPort}/something`, {
+      headers: { 
+        // The proxy.web() call in the request uses the static override.
+        // We test via the proxy server with a separate method.
+        // Instead, create an http server that uses proxy.web directly.
+      },
+    });
+
+    // This test is just using the function target.
+    // For per-request override, we need a different setup.
+    const body = await res.text();
+    expect(body).toBe("target1");
+
+    proxy.close();
+    target1.close();
+    target2.close();
+  });
+
+  it("per-request static target overrides function target", async () => {
+    const port1 = await getPort();
+    const port2 = await getPort();
+    const proxyPort = await getPort();
+
+    const target1 = http.createServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "text/plain" });
+      res.write("target1");
+      res.end();
+    });
+    target1.listen(port1);
+
+    const target2 = http.createServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "text/plain" });
+      res.write("target2");
+      res.end();
+    });
+    target2.listen(port2);
+
+    const proxy = httpProxy.createServer({
+      target: () => `http://localhost:${port1}`,
+    });
+
+    // Create a server that uses proxy.web with per-request options
+    const server = http.createServer((req, res) => {
+      proxy.web(req, res, { target: `http://localhost:${port2}` });
+    });
+    server.listen(proxyPort);
+
+    const res = await fetch(`http://localhost:${proxyPort}/`);
+    const body = await res.text();
+    expect(body).toBe("target2");
+
+    proxy.close();
+    server.close();
+    target1.close();
+    target2.close();
+  });
+
+  it("function target returning {port, host} object", async () => {
+    const port = await getPort();
+    const proxyPort = await getPort();
+
+    const target = http.createServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "text/plain" });
+      res.write("object target");
+      res.end();
+    });
+    target.listen(port);
+
+    const proxy = httpProxy
+      .createServer({
+        target: () => ({ port, host: "localhost" } as httpProxy.ProxyTarget),
+      })
+      .listen(proxyPort);
+    proxy.on("error", (_e) => {});
+
+    const res = await fetch(`http://localhost:${proxyPort}/`);
+    const body = await res.text();
+    expect(body).toBe("object target");
+
+    proxy.close();
+    target.close();
+  });
+});

--- a/lib/test/http/dynamic-target.test.ts
+++ b/lib/test/http/dynamic-target.test.ts
@@ -11,6 +11,7 @@ import * as httpProxy from "../..";
 import getPort from "../get-port";
 import fetch from "node-fetch";
 import { describe, it, expect, afterAll, beforeAll } from "vitest";
+import { once } from "node:events";
 
 async function setup() {
   const port1 = await getPort();
@@ -79,50 +80,6 @@ describe("dynamic target function", () => {
 });
 
 describe("dynamic target with per-request override", () => {
-  it("per-request target overrides the function target", async () => {
-    const port1 = await getPort();
-    const port2 = await getPort();
-    const proxyPort = await getPort();
-
-    const target1 = http.createServer((_req, res) => {
-      res.writeHead(200, { "Content-Type": "text/plain" });
-      res.write("target1");
-      res.end();
-    });
-    target1.listen(port1);
-
-    const target2 = http.createServer((_req, res) => {
-      res.writeHead(200, { "Content-Type": "text/plain" });
-      res.write("target2");
-      res.end();
-    });
-    target2.listen(port2);
-
-    const proxy = httpProxy
-      .createServer({
-        target: (_req: http.IncomingMessage) => `http://localhost:${port1}`,
-      })
-      .listen(proxyPort);
-    proxy.on("error", (_e) => {});
-
-    const res = await fetch(`http://localhost:${proxyPort}/something`, {
-      headers: { 
-        // The proxy.web() call in the request uses the static override.
-        // We test via the proxy server with a separate method.
-        // Instead, create an http server that uses proxy.web directly.
-      },
-    });
-
-    // This test is just using the function target.
-    // For per-request override, we need a different setup.
-    const body = await res.text();
-    expect(body).toBe("target1");
-
-    proxy.close();
-    target1.close();
-    target2.close();
-  });
-
   it("per-request static target overrides function target", async () => {
     const port1 = await getPort();
     const port2 = await getPort();
@@ -186,5 +143,37 @@ describe("dynamic target with per-request override", () => {
 
     proxy.close();
     target.close();
+  });
+});
+
+describe("dynamic target error handling", () => {
+  it("emits error when target function throws", async () => {
+    const proxyPort = await getPort();
+
+    const errorMessage = "target resolution failed";
+    const proxy = httpProxy.createServer({
+      target: () => {
+        throw new Error(errorMessage);
+      },
+    });
+
+    const errorPromise = new Promise<Error>((resolve) => {
+      proxy.on("error", (err: Error) => resolve(err));
+    });
+
+    const server = http.createServer((req, res) => {
+      proxy.web(req, res);
+    });
+    server.listen(proxyPort);
+    // Server won't send back a response (emit error + return), but we don't
+    // need the fetch to complete — only the error to fire.
+    await once(server, "listening");
+    fetch(`http://localhost:${proxyPort}/`).catch(() => {});
+
+    const err = await errorPromise;
+    expect(err.message).toBe(errorMessage);
+
+    server.close();
+    proxy.close();
   });
 });

--- a/lib/test/websocket/dynamic-target-ws.test.ts
+++ b/lib/test/websocket/dynamic-target-ws.test.ts
@@ -1,0 +1,114 @@
+/*
+Test dynamic target function with WebSocket proxying
+
+DEVELOPMENT:
+
+ pnpm test dynamic-target-ws.test.ts
+*/
+
+import * as http from "node:http";
+import * as httpProxy from "../..";
+import getPort from "../get-port";
+import { once } from "node:events";
+import { describe, it, beforeAll, afterAll, expect } from "vitest";
+
+describe("dynamic target function with WebSocket", () => {
+  let ports: Record<"ws1" | "ws2" | "proxy", number>;
+  beforeAll(async () => {
+    ports = {
+      ws1: await getPort(),
+      ws2: await getPort(),
+      proxy: await getPort(),
+    };
+  });
+
+  let servers: Record<string, http.Server | httpProxy.ProxyServer> = {};
+
+  it("create two target WS echo servers", async () => {
+    const s1 = http.createServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "text/plain" });
+      res.end("ws1");
+    });
+    s1.on("upgrade", (_req, socket) => {
+      socket.write(
+        "HTTP/1.1 101 Web Socket Protocol Handshake\r\n" +
+          "Upgrade: WebSocket\r\n" +
+          "Connection: Upgrade\r\n" +
+          "X-Target: ws1\r\n" +
+          "\r\n",
+      );
+      socket.pipe(socket);
+    });
+    s1.listen(ports.ws1);
+    servers.ws1 = s1;
+
+    const s2 = http.createServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "text/plain" });
+      res.end("ws2");
+    });
+    s2.on("upgrade", (_req, socket) => {
+      socket.write(
+        "HTTP/1.1 101 Web Socket Protocol Handshake\r\n" +
+          "Upgrade: WebSocket\r\n" +
+          "Connection: Upgrade\r\n" +
+          "X-Target: ws2\r\n" +
+          "\r\n",
+      );
+      socket.pipe(socket);
+    });
+    s2.listen(ports.ws2);
+    servers.ws2 = s2;
+  });
+
+  it("create proxy with dynamic WS target function", async () => {
+    servers.proxy = httpProxy
+      .createServer({
+        ws: true,
+        target: (req: http.IncomingMessage) => {
+          if (req.url?.startsWith("/ws2")) {
+            return `ws://localhost:${ports.ws2}`;
+          }
+          return `ws://localhost:${ports.ws1}`;
+        },
+      })
+      .listen(ports.proxy);
+  });
+
+  it("upgrade through proxy to ws1", async () => {
+    const options = {
+      port: ports.proxy,
+      host: "localhost",
+      path: "/ws1",
+      headers: {
+        Connection: "Upgrade",
+        Upgrade: "websocket",
+      },
+    };
+    const req = http.request(options);
+    req.end();
+    const [res] = await once(req, "upgrade");
+    expect(res.headers["x-target"]).toBe("ws1");
+    res.socket.end();
+  });
+
+  it("upgrade through proxy to ws2", async () => {
+    const options = {
+      port: ports.proxy,
+      host: "localhost",
+      path: "/ws2",
+      headers: {
+        Connection: "Upgrade",
+        Upgrade: "websocket",
+      },
+    };
+    const req = http.request(options);
+    req.end();
+    const [res] = await once(req, "upgrade");
+    expect(res.headers["x-target"]).toBe("ws2");
+    res.socket.end();
+  });
+
+  afterAll(() => {
+    Object.values(servers).map((x: any) => x?.close());
+  });
+});


### PR DESCRIPTION
Allow `target` option to accept a function `(req) => ProxyTarget` in addition to a static `ProxyTarget`, enabling per-request dynamic routing.

## Changes

- **`lib/http-proxy/index.ts`**: Added `ProxyTargetFunction` type, changed `ServerOptions.target` to accept `ProxyTarget | ProxyTargetFunction`. Function target is resolved in `createRightProxy` before any passes run, so all downstream code sees a resolved static target.
- **`lib/index.ts`**: Exported `ProxyTargetFunction` type.
- **`lib/test/http/dynamic-target.test.ts`**: 6 new tests covering path-based routing, `{port, host}` object return, and per-request override.

## Example

```ts
const proxy = createProxyServer({
  target: (req) => {
    if (req.url?.startsWith("/api/v2")) return "http://localhost:3001";
    return "http://localhost:3000";
  },
});
```

---

🤖 This code was written by AI (OpenCode / DeepSeek v4 Pro).